### PR TITLE
Remove deprecated rsslink

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -12,15 +12,17 @@
     <link rel="stylesheet" href="{{ "custom.css" | relURL }}?{{ .Site.Params.theme_seconds }}">
 
 	<!-- RSS etc -->
-    {{- if .OutputFormats.Get "RSS" -}}
     {{- with .OutputFormats.Get "RSS" -}}
-    <link href="{{ .RelPermalink }}" rel="alternate" type="application/rss+xml" title="{{ $.Site.Title }}" />
-    <link href="{{ .RelPermalink }}" rel="alternate" type="application/rss+xml" title="{{ $.Site.Title }}" />
-    <link href="{{ "podcast.xml" | absURL }}" rel="alternate" type="application/rss+xml" title="Podcast" />
+    <link rel="alternate" type="application/rss+xml" title="{{ $.Site.Title }}"  href="{{ .RelPermalink }}"/>
+    {{- with $.Site.Params.podcast_title }}
+    <link rel="alternate" type="application/rss+xml" title="{{ . }}"  href="{{ "podcast.xml" | absURL }}" />
+    {{ else }}
+    <link rel="alternate" type="application/rss+xml" title="Podcast" href="{{ "podcast.xml" | absURL }}" />
+    {{ end -}}
     <link rel="alternate" type="application/json" title="{{ $.Site.Title }}" href="{{ "feed.json" | absURL }}" />
     <link rel="EditURI" type="application/rsd+xml" href="{{ "rsd.xml" | absURL }}" />
     {{- end -}}
-    {{ end -}}
+   
 
 
     {{ with .Site.Params.twitter_username }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -10,12 +10,13 @@
     <link rel="shortcut icon" href="https://micro.blog/{{ .Site.Author.username }}/favicon.png" type="image/x-icon" />
     <link rel="stylesheet" href="{{ "css/style.css" | relURL }}?{{ .Site.Params.theme_seconds }}">
     <link rel="stylesheet" href="{{ "custom.css" | relURL }}?{{ .Site.Params.theme_seconds }}">
-    {{ if .RSSLink -}}
-        <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
-        <link href="{{ " podcast.xml " | absURL }}" rel="alternate" type="application/rss+xml" title="Podcast" />
-        <link rel="alternate" type="application/json" title="{{ .Site.Title }}" href="{{ " feed.json " | absURL }}" />
-        <link rel="EditURI" type="application/rsd+xml" href="{{ " rsd.xml " | absURL }}" />
-    {{ end -}}
+
+<!-- RSS etc -->
+  {{ range .AlternativeOutputFormats -}}
+    {{ printf `<link href="%s" rel="%s" type="%s" title="%s" />` .Permalink .Rel .MediaType.Type $.Site.Title | safeHTML }}
+  {{ end -}}
+
+
     {{ with .Site.Params.twitter_username }}
         <link rel="me" href="https://twitter.com/{{ . }}" />
     {{ end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -11,20 +11,26 @@
     <link rel="stylesheet" href="{{ "css/style.css" | relURL }}?{{ .Site.Params.theme_seconds }}">
     <link rel="stylesheet" href="{{ "custom.css" | relURL }}?{{ .Site.Params.theme_seconds }}">
 
-<!-- RSS etc -->
-  {{ range .AlternativeOutputFormats -}}
-    {{ printf `<link href="%s" rel="%s" type="%s" title="%s" />` .Permalink .Rel .MediaType.Type $.Site.Title | safeHTML }}
-  {{ end -}}
+	<!-- RSS etc -->
+    {{- if .OutputFormats.Get "RSS" -}}
+    {{- with .OutputFormats.Get "RSS" -}}
+    <link href="{{ .RelPermalink }}" rel="alternate" type="application/rss+xml" title="{{ $.Site.Title }}" />
+    <link href="{{ .RelPermalink }}" rel="alternate" type="application/rss+xml" title="{{ $.Site.Title }}" />
+    <link href="{{ "podcast.xml" | absURL }}" rel="alternate" type="application/rss+xml" title="Podcast" />
+    <link rel="alternate" type="application/json" title="{{ $.Site.Title }}" href="{{ "feed.json" | absURL }}" />
+    <link rel="EditURI" type="application/rsd+xml" href="{{ "rsd.xml" | absURL }}" />
+    {{- end -}}
+    {{ end -}}
 
 
     {{ with .Site.Params.twitter_username }}
-        <link rel="me" href="https://twitter.com/{{ . }}" />
+    <link rel="me" href="https://twitter.com/{{ . }}" />
     {{ end }}
     {{ with .Site.Params.github_username }}
-        <link rel="me" href="https://github.com/{{ . }}" />
+    <link rel="me" href="https://github.com/{{ . }}" />
     {{ end }}
     {{ with .Site.Params.instagram_username }}
-        <link rel="me" href="https://instagram.com/{{ . }}" />
+    <link rel="me" href="https://instagram.com/{{ . }}" />
     {{ end }}
     <link rel="me" href="https://micro.blog/{{ .Site.Author.username }}" />
     <link rel="authorization_endpoint" href="https://micro.blog/indieauth/auth" />
@@ -35,7 +41,7 @@
     <link rel="subscribe" href="https://micro.blog/users/follow" />
     <link rel="canonical" href="{{ .Permalink }}"> 
     {{ range .Site.Params.plugins_css }}
-        <link rel="stylesheet" href="{{ . }}" />
+    <link rel="stylesheet" href="{{ . }}" />
     {{ end }}
     {{ range $filename := .Site.Params.plugins_html }}
         {{ partial $filename $ }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -11,11 +11,13 @@
     <link rel="stylesheet" href="{{ "css/style.css" | relURL }}?{{ .Site.Params.theme_seconds }}">
     <link rel="stylesheet" href="{{ "custom.css" | relURL }}?{{ .Site.Params.theme_seconds }}">
 
-<!-- RSS etc -->
-  {{ range .AlternativeOutputFormats -}}
-    {{ printf `<link href="%s" rel="%s" type="%s" title="%s" />` .Permalink .Rel .MediaType.Type $.Site.Title | safeHTML }}
-  {{ end -}}
-
+    <!-- RSS etc -->
+    {{- if .RSSLink }}
+    <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+    <link href="{{ "podcast.xml" | absURL }}" rel="alternate" type="application/rss+xml" title="Podcast" />
+    <link rel="alternate" type="application/json" title="{{ .Site.Title }}" href="{{ "feed.json" | absURL }}" />
+    <link rel="EditURI" type="application/rsd+xml" href="{{ "rsd.xml" | absURL }}" />
+    {{ end -}}
 
     {{ with .Site.Params.twitter_username }}
         <link rel="me" href="https://twitter.com/{{ . }}" />


### PR DESCRIPTION
Change the format of the RSS output.

Sorry about the change in whitespace that was selected as part of the pull request and I don't want to spend 30 minutes into hot to change lines in the web interface for GitHub tonight.